### PR TITLE
Improve `must_be_string*` functions

### DIFF
--- a/src/formal/form.gleam
+++ b/src/formal/form.gleam
@@ -600,20 +600,20 @@ pub fn must_equal(
   }
 }
 
-/// Assert that the string has at least the given length.
+/// Assert that the string is longer than the given length.
 ///
 /// # Examples
 ///
 /// ```gleam
 /// let check = must_be_string_longer_than(4)
 /// check("hello")
-/// # -> Ok("hello")
+/// // -> Ok("hello")
 /// ```
 ///
 /// ```gleam
-/// let check = must_be_string_longer_than(4)
+/// let check = must_be_string_longer_than(2)
 /// check("hi")
-/// # -> Error("Must be longer than 2 characters")
+/// // -> Error("Must be longer than 2 characters")
 /// ```
 ///
 pub fn must_be_string_longer_than(
@@ -622,7 +622,36 @@ pub fn must_be_string_longer_than(
   fn(input) {
     case string.length(input) > length {
       True -> Ok(input)
-      False -> Error("Must be longer than 2 characters")
+      False ->
+        Error("Must be longer than " <> int.to_string(length) <> " characters")
+    }
+  }
+}
+
+/// Assert that the string is shorter than the given length.
+///
+/// # Examples
+///
+/// ```gleam
+/// let check = must_be_string_shorter_than(3)
+/// check("hi")
+/// // -> Ok("hi")
+/// ```
+///
+/// ```gleam
+/// let check = must_be_string_shorter_than(5)
+/// check("hello")
+/// // -> Error("Must be shorter than 5 characters")
+/// ```
+///
+pub fn must_be_string_shorter_than(
+  length: Int,
+) -> fn(String) -> Result(String, String) {
+  fn(input) {
+    case string.length(input) < length {
+      True -> Ok(input)
+      False ->
+        Error("Must be shorter than " <> int.to_string(length) <> " characters")
     }
   }
 }

--- a/test/formal_test.gleam
+++ b/test/formal_test.gleam
@@ -342,3 +342,13 @@ pub fn must_be_string_longer_than_error_test() {
   form.must_be_string_longer_than(2)("ab")
   |> should.equal(Error("Must be longer than 2 characters"))
 }
+
+pub fn must_be_string_shorter_than_ok_test() {
+  form.must_be_string_shorter_than(3)("hi")
+  |> should.equal(Ok("hi"))
+}
+
+pub fn must_be_string_shorter_than_error_test() {
+  form.must_be_string_shorter_than(5)("hello")
+  |> should.equal(Error("Must be shorter than 5 characters"))
+}


### PR DESCRIPTION
Fixed `must_be_string_longer_than`
- Description stated "the string has at least the given length", which implies a `>=` check instead of the actual `>`.
- Error string was hardcoded to say "Must be longer than 2 characters" instead of using the `input`.

Added new fn `must_be_string_shorter_than` as it felt like it was missing + tests for it.