### PR TITLE
Functions to work with field

### DIFF
--- a/src/formal/form.gleam
+++ b/src/formal/form.gleam
@@ -316,11 +316,7 @@ pub fn set_field_values(
 ///   |> form.add_field_value("species", "cat")
 /// ```
 ///
-pub fn add_field_value(
-  form: Form(a),
-  name: String,
-  value: String,
-) -> Form(a) {
+pub fn add_field_value(form: Form(a), name: String, value: String) -> Form(a) {
   Form(..form, values: [#(name, value), ..form.values])
 }
 

--- a/src/formal/form.gleam
+++ b/src/formal/form.gleam
@@ -276,6 +276,76 @@ pub fn set_values(form: Form(a), values: List(#(String, String))) -> Form(a) {
   Form(..form, values:)
 }
 
+/// Replace any existing values of a form field with new values. This is useful
+/// for setting multiple values on a single field, such as the selected options
+/// of a multi-select input.
+///
+/// ## Example
+///
+/// ```gleam
+/// let form =
+///   form.new(schema)
+///   |> form.set_field_values("species", [
+///     #("species", "cat"),
+///     #("species", "dog"),
+///     #("species", "rabbit"),
+///   ])
+/// ```
+///
+pub fn set_field_values(
+  form: Form(a),
+  name: String,
+  values: List(#(String, String)),
+) -> Form(a) {
+  let values =
+    all_values(form)
+    |> list.filter(fn(pair) { pair.0 != name })
+    |> list.append(values)
+  Form(..form, values:)
+}
+
+/// Add a single value to a form field. Existing values for the field are
+/// preserved, so this is useful for appending to a multi-value field such as
+/// a list of checkboxes or multi-select options.
+///
+/// ## Example
+///
+/// ```gleam
+/// let form =
+///   form.new(schema)
+///   |> form.add_field_value("species", "cat")
+/// ```
+///
+pub fn add_field_value(
+  form: Form(a),
+  name: String,
+  value: String,
+) -> Form(a) {
+  Form(..form, values: [#(name, value), ..form.values])
+}
+
+/// Remove a single value from a form field. Other values for the field are
+/// preserved, as are values for any other field.
+///
+/// ## Example
+///
+/// ```gleam
+/// let form =
+///   form.new(schema)
+///   |> form.remove_field_value("species", "cat")
+/// ```
+///
+pub fn remove_field_value(
+  form: Form(a),
+  name: String,
+  value: String,
+) -> Form(a) {
+  let values =
+    all_values(form)
+    |> list.filter(fn(pair) { pair.0 != name || pair.1 != value })
+  Form(..form, values:)
+}
+
 /// A parser that applies another parser if there is a non-empty-string input
 /// value for the field.
 ///

--- a/test/formal/form_test.gleam
+++ b/test/formal/form_test.gleam
@@ -1193,3 +1193,125 @@ pub fn add_values_test() {
     |> form.all_values
     == [#("a", "3"), #("a", "1"), #("b", "2")]
 }
+
+pub fn set_field_values_test() {
+  let form =
+    form.new({
+      use species <- form.field(
+        "species",
+        form.parse_list(form.parse_string),
+      )
+      form.success(species)
+    })
+
+  // Replaces any existing values of the named field
+  let form =
+    form
+    |> form.add_string("species", "hamster")
+    |> form.set_field_values("species", [
+      #("species", "cat"),
+      #("species", "dog"),
+      #("species", "rabbit"),
+    ])
+
+  assert form.field_values(form, "species") == ["cat", "dog", "rabbit"]
+
+  assert form
+    |> form.run
+    == Ok(["cat", "dog", "rabbit"])
+
+  // Other fields are preserved
+  let form =
+    form
+    |> form.set_field_values("species", [#("species", "fish")])
+    |> form.add_string("other", "value")
+
+  assert form.field_values(form, "species") == ["fish"]
+  assert form.field_values(form, "other") == ["value"]
+}
+
+pub fn add_field_value_test() {
+  let form =
+    form.new({
+      use species <- form.field(
+        "species",
+        form.parse_list(form.parse_string),
+      )
+      form.success(species)
+    })
+
+  // Appends a value to the named field
+  let form =
+    form
+    |> form.add_field_value("species", "cat")
+    |> form.add_field_value("species", "dog")
+
+  assert form.field_values(form, "species") == ["dog", "cat"]
+
+  assert form
+    |> form.run
+    == Ok(["dog", "cat"])
+
+  // Other fields are preserved
+  let form =
+    form.new({
+      use species <- form.field(
+        "species",
+        form.parse_list(form.parse_string),
+      )
+      form.success(species)
+    })
+    |> form.add_string("other", "value")
+    |> form.add_field_value("species", "rabbit")
+
+  assert form.field_values(form, "other") == ["value"]
+  assert form.field_values(form, "species") == ["rabbit"]
+}
+
+pub fn remove_field_value_test() {
+  let form =
+    form.new({
+      use species <- form.field(
+        "species",
+        form.parse_list(form.parse_string),
+      )
+      form.success(species)
+    })
+
+  // Removes only the matching name+value pair
+  let form =
+    form
+    |> form.set_field_values("species", [
+      #("species", "cat"),
+      #("species", "dog"),
+      #("species", "rabbit"),
+    ])
+    |> form.remove_field_value("species", "dog")
+
+  assert form.field_values(form, "species") == ["cat", "rabbit"]
+
+  assert form
+    |> form.run
+    == Ok(["cat", "rabbit"])
+
+  // Removing a value that doesn't exist is a no-op
+  let form =
+    form
+    |> form.set_field_values("species", [#("species", "cat")])
+    |> form.remove_field_value("species", "hamster")
+
+  assert form.field_values(form, "species") == ["cat"]
+
+  // Other fields are preserved
+  let form =
+    form
+    |> form.set_field_values("species", [
+      #("species", "cat"),
+      #("species", "dog"),
+    ])
+    |> form.add_string("other", "value")
+    |> form.remove_field_value("species", "cat")
+
+  assert form.field_values(form, "species") == ["dog"]
+  assert form.field_values(form, "other") == ["value"]
+}

--- a/test/formal/form_test.gleam
+++ b/test/formal/form_test.gleam
@@ -1197,10 +1197,7 @@ pub fn add_values_test() {
 pub fn set_field_values_test() {
   let form =
     form.new({
-      use species <- form.field(
-        "species",
-        form.parse_list(form.parse_string),
-      )
+      use species <- form.field("species", form.parse_list(form.parse_string))
       form.success(species)
     })
 
@@ -1233,10 +1230,7 @@ pub fn set_field_values_test() {
 pub fn add_field_value_test() {
   let form =
     form.new({
-      use species <- form.field(
-        "species",
-        form.parse_list(form.parse_string),
-      )
+      use species <- form.field("species", form.parse_list(form.parse_string))
       form.success(species)
     })
 
@@ -1255,10 +1249,7 @@ pub fn add_field_value_test() {
   // Other fields are preserved
   let form =
     form.new({
-      use species <- form.field(
-        "species",
-        form.parse_list(form.parse_string),
-      )
+      use species <- form.field("species", form.parse_list(form.parse_string))
       form.success(species)
     })
     |> form.add_string("other", "value")
@@ -1271,10 +1262,7 @@ pub fn add_field_value_test() {
 pub fn remove_field_value_test() {
   let form =
     form.new({
-      use species <- form.field(
-        "species",
-        form.parse_list(form.parse_string),
-      )
+      use species <- form.field("species", form.parse_list(form.parse_string))
       form.success(species)
     })
 


### PR DESCRIPTION
When working with multi-value fields (for checkboxes, multi-select, etc.), I found that to toggle a value, I have to write long code with current API.

For example, let have a form for editing a zoo enclosure:

```gleam
pub type Enclosure {
  Enclosure(name: String, animals: List(String))
}

fn enclosure_form() -> form.Form(Enclosure) {
  form.new({
    use name <- form.field("name", form.parse_string)
    use animals <- form.field("animal", form.parse_list(form.parse_string))
    form.success(Enclosure(name:, animals:))
  })
}
```

To add a value with current API:

```gleam
fn add_animal(form: form.Form(Enclosure), animal: String) -> form.Form(Enclosure) {
  let other_values =
    form.all_values(form)
    |> list.filter(fn(pair) { pair.0 != "animal" })

  form
  |> form.set_values(list.append(other_values, [#("animal", animal)]))
}
```

To remove a value with current API:

```gleam
fn remove_animal(form: form.Form(Enclosure), animal: String) -> form.Form(Enclosure) {
  let remaining =
    form.all_values(form)
    |> list.filter(fn(pair) { pair.0 != "animal" || pair.1 != animal })

  form |> form.set_values(remaining)
}
```


This PR introduce new helpers to let write less code:


```gleam
fn add_animal(form: form.Form(Enclosure), animal: String) -> form.Form(Enclosure) {
  form |> form.add_field_value("animal", animal)
}

fn remove_animal(form: form.Form(Enclosure), animal: String) -> form.Form(Enclosure) {
  form |> form.remove_field_value("animal", animal)
}
```


Hope that it matches "formal" design.
